### PR TITLE
HAGOV-2: Camera reparent transition

### DIFF
--- a/Scripts/Levels/bmu_chamber_area.gd
+++ b/Scripts/Levels/bmu_chamber_area.gd
@@ -17,8 +17,6 @@ extends Area3D
 var player_clamped: bool = false
 var adjusting: bool = false
 
-const CAMERA_DISTANCE_SMOOTHING = 1.35 # NOTE: No tengo idea por que, pero se ve mejor.
-
 func _ready() -> void:
 	collision_shape.shape.size = size
 	camera_marker.position.y = size.y / 2

--- a/Scripts/Levels/bmu_chamber_area.gd
+++ b/Scripts/Levels/bmu_chamber_area.gd
@@ -32,7 +32,7 @@ func _physics_process(_delta: float) -> void:
 		# NOTE: Se puede resolver con una StaticBody invisible, quizas.
 		player.ClampToCube(global_position, size)
 
-func _process(delta: float) -> void:
+func _process(_delta: float) -> void:
 	if enemies.size() == 0 and not adjusting:
 		adjusting = true
 		await _on_room_finished()
@@ -54,13 +54,14 @@ func _on_body_entered(body: Node3D) -> void:
 func _on_room_finished() -> void:
 	var tween = create_tween()
 	tween.set_trans(Tween.TRANS_SINE)
+	camera.reparent(player, true)
 	tween.tween_property(
-		camera, "global_position",
-		player.global_position + camera.positionFromTarget / CAMERA_DISTANCE_SMOOTHING,
+		camera, "position",
+		camera.positionFromTarget,
 		camera_animation_duration,
 	)
 	await tween.finished
-	await camera.ReparentAndPosition(player)
+	camera.ReparentAndPosition(player)
 	player_clamped = false
 	# NOTE: Para reducir checks en cada frame, y porque una vez superado la entidad pierde sentido.
 	queue_free()


### PR DESCRIPTION
Este PR tiene Como objetivo suavizar la transición de la cámara, porque al hacer primero el transition y después el reparenting, la cámara sufría un ajustazo violento, como Argentina, si el jugador se movía mientras ocurría la transición. Ahora tenemos 3 pasos: reparent, transición, reposition fino, para que quede todo en orden. El último paso es quizás poco útil, porque en teoría el tween deja la cámara exactamente en el pixel que tiene que estar, pero como lo async de los tweens a veces genera comportamientos raros, un set de posición no cuesta nada en términos computacionales.